### PR TITLE
Use requirements.txt and .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,6 @@
             "request": "launch",
             "program": "${file}",
             "args": ["--color=yes"],
-            "env": {"DOCKER_HOST": "ssh://coffee"},
             "console": "integratedTerminal",
             "justMyCode": false
         }

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,5 +6,3 @@ WORKDIR /app
 
 # Copy the current directory contents into the container at /app
 COPY ./ /app
-
-ENV DOCKER_HOST="ssh://coffee"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+docker ~=6.1.3
+pytest ~=7.4.0
+pytest-dotenv ~=0.5.2


### PR DESCRIPTION
# 1. Add a `requirements.txt` file
Now, anyone can install the necessary requirements by running `pip install -r requirements.txt`

# 2. Modify the project to use a `.env` file to define environment variables, such as `DOCKER_HOST`
By installing [`pytest-dotenv`](https://pypi.org/project/pytest-dotenv/) (via the `requirements.txt` file), `pytest` will now load environment variables defined in a `.env` file, if one exists.

E.g, one might want the following:
```env
DOCKER_HOST=ssh://coffee
```

The `.env` file is ignored by git at the moment so that anyone can have their own `.env` file with the specific environment variables they want locally. If we want to commit a default one in the future, we can un-ignore `.env` and add configuration so that other files get loaded automatically as well, e.g. `.env.local` or `.env.test`

# To test this PR:
- run `pip install -r requirements.txt`
- add a `.env` file for yourself if you need one