### PR TITLE
Use pytest-xdist to speed up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,20 @@ The name `rosetta-io` is an hommage to [Rosetta Code](https://rosettacode.org/wi
 
 ### Setup
 
-1. Put any environment variables you need in a `.env` file, which will be loaded by  `pytest` before it runs the tests.
+1. Put any environment variables specific for your machine in a `.env` file, which will be loaded by `pytest` before it runs the test suite.
 
-    E.g. if you want to run the test suite examples on a different Docker host, set the `DOCKER_HOST` env variable.
+    A few environment variables to consider:
+    - [docker environment variables][env-vars-docker], e.g. `DOCKER_HOST` if you want to run the test suite examples on a different Docker host, or use other Docker settings
+    - [`PYTEST_XDIST_AUTO_NUM_WORKERS`][env-vars-pytest-xdist] can be set to the number of worker processes to run the tests in if `pytest-xdist`'s `auto` setting is not what you want.
+    - [`pytest`][env-vars-pytest] environment variables
 
-3. Make sure you Docker host is running
+2. Make sure you Docker host is running
 
 ### Run the test suite
 
 Run `pytest` from the command line. If you are using VSCode you'll see the tests in the Testing panel.
+
+
+[env-vars-docker]: https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+[env-vars-pytest-xdist]: https://pytest-xdist.readthedocs.io/en/stable/distribution.html
+[env-vars-pytest]: https://docs.pytest.org/en/7.4.x/reference/reference.html#environment-variables

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,1 +1,2 @@
 [pytest]
+addopts = -n auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 docker ~=6.1.3
 pytest ~=7.4.0
 pytest-dotenv ~=0.5.2
+pytest-xdist ~=3.3.1
+pytest-xdist[psutil] ~=3.3.1


### PR DESCRIPTION
Use the [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/) package to run the tests in parallel. On my machine it speeds things up 2-3x.

To use:
1. `pip install -r requirements.txt`
2. Put this is your `.env`: `PYTEST_XDIST_AUTO_NUM_WORKERS=8`. The number of workers used will default to the number of cores your processor has, but if you're running the tests against a remote docker host (like `ssh://coffee`), you'll probably want to set the it to the number of cores of the remote host, and the `coffee` machine has 8 cores.
3. Run the tests.

## TODO
- [x] add a README (merge #20 or write another)
- [x] then put a note about `PYTEST_XDIST_AUTO_NUM_WORKERS` in the README