### PR TITLE
Fix xdist race condition

### DIFF
--- a/python/locking/__init__.py
+++ b/python/locking/__init__.py
@@ -5,7 +5,7 @@ from ilock import ILock
 
 
 @contextmanager
-def lock_for_early_bird(tmp_dir: pathlib.Path, *lock_keys: [str], worker_id = 'worker'):
+def early_bird_lock(tmp_dir: pathlib.Path, *lock_keys: [str], worker_id = 'worker'):
     """
     A context manager that either:
     - yields True if you are the "early bird" (the first worker to call this function
@@ -19,7 +19,7 @@ def lock_for_early_bird(tmp_dir: pathlib.Path, *lock_keys: [str], worker_id = 'w
 
     Use like so:
 
-    lock_for_early_bird(mytmp_dir, testrun_id, 'build-image') as should_build:
+    early_bird_lock(mytmp_dir, testrun_id, 'build-image') as should_build:
       if should_build:
         # ... build the image. Other worker will wait until this is done.
       else:

--- a/python/locking/__init__.py
+++ b/python/locking/__init__.py
@@ -1,0 +1,52 @@
+import pathlib
+from contextlib import contextmanager
+
+from ilock import ILock
+
+
+@contextmanager
+def lock_for_early_bird(tmp_dir: pathlib.Path, *lock_keys: [str], worker_id = 'worker'):
+    """
+    A context manager that either:
+    - yields True if you are the "early bird" (the first worker to call this function
+    with the tmp_dir and lock_keys you provided)
+    - yields False only after the the early bird has finished (i.e. exited the managed context).
+
+    The lock that manages who is and isn't the easly bird:
+    - is identified by the `tmp_dir` and the `lock_keys`
+    - is created if it doesn't exist
+    - is saved as a file in the tmp_dir path
+
+    Use like so:
+
+    lock_for_early_bird(mytmp_dir, testrun_id, 'build-image') as should_build:
+      if should_build:
+        # ... build the image. Other worker will wait until this is done.
+      else:
+        # ... image is already built
+    """
+
+    lock_id = "once-per-" + "--".join(lock_keys)
+
+    lock_file = tmp_dir / f"{lock_id}.lock"
+
+    is_early_bird = None
+
+    # use a file-based lock to ensure only one worker process is the early bird
+    with ILock(lock_id):
+
+        # if this file doesn't exist, that means the caller is the early bird
+        is_early_bird = not lock_file.is_file()
+
+        if is_early_bird:
+            # create the file so that subsequent workers will see the file and
+            # know they aren't the early bird
+            lock_file.write_text(f"lock acquired by {worker_id}")
+
+            # yield inside the lock so that other workers have to wait until the
+            # early bird is finished
+            yield is_early_bird
+
+    if not is_early_bird:
+        # yield outside the lock so that other worker's aren't delayed
+        yield is_early_bird

--- a/python/locking/__init__.py
+++ b/python/locking/__init__.py
@@ -12,7 +12,7 @@ def early_bird_lock(tmp_dir: pathlib.Path, *lock_keys: [str], worker_id = 'worke
     with the tmp_dir and lock_keys you provided)
     - yields False only after the the early bird has finished (i.e. exited the managed context).
 
-    The lock that manages who is and isn't the easly bird:
+    The lock that manages who is and isn't the early bird:
     - is identified by the `tmp_dir` and the `lock_keys`
     - is created if it doesn't exist
     - is saved as a file in the tmp_dir path

--- a/python/test_python.py
+++ b/python/test_python.py
@@ -32,26 +32,23 @@ def once_per_test_suite_run(tmp_path_factory, testrun_uid, worker_id):
     return once_per_this_test_run
 
 @pytest.fixture
-def docker_image(docker_client: docker.DockerClient, once_per_test_suite_run) -> docker.models.images.Image:
+def docker_image(docker_client: docker.DockerClient, once_per_test_suite_run) -> str:
     image_name = 'python-rosetta'
     build_context = './python/'
 
     with once_per_test_suite_run("build-image", image_name) as should_build:
         if should_build:
-            image, logs = docker_client.images.build(path=build_context, tag=image_name)
+            _, logs = docker_client.images.build(path=build_context, tag=image_name)
             for log_line in logs:
                 print(log_line)
 
-        else:
-            image = docker_client.images.get(image_name)
-
-    return image
+    return image_name
 
 
 @dataclass
 class DockerRunner:
     client: docker.DockerClient
-    image: docker.models.images.Image
+    image: str
     container: docker.models.containers.Container = None
 
     def run(self, command):

--- a/python/test_python.py
+++ b/python/test_python.py
@@ -36,7 +36,7 @@ def docker_image(docker_client: docker.DockerClient, once_per_test_suite_run) ->
     image_name = 'python-rosetta'
     build_context = './python/'
 
-    with once_per_test_suite_run("build-image") as should_build:
+    with once_per_test_suite_run("build-image", image_name) as should_build:
         if should_build:
             image, logs = docker_client.images.build(path=build_context, tag=image_name)
             for log_line in logs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest ~=7.4.0
 pytest-dotenv ~=0.5.2
 pytest-xdist ~=3.3.1
 pytest-xdist[psutil] ~=3.3.1
+ilock ~=1.0.3


### PR DESCRIPTION
This fixes the race condition caused by using `pytest-xdist`. It uses a file-based lock mechanism to keeping docker images from being built at the same time. Instead, the first worker to attempt to build the image will "win" and get to build the image. The other workers that attempt it "lose" and will wait until the image is built.

This seems to solve the problem but I should mention that I'm worried the complexity of `pytest-xdist`'s concurrency model, plus file-based locking may bite us later.
