### PR TITLE
[Issue #15] Test case: Streaming Input

### DIFF
--- a/python/streaming_stdin.py
+++ b/python/streaming_stdin.py
@@ -1,0 +1,8 @@
+"""Script reads streaming input text and prints capitalized string to stdout"""
+
+while True:
+    try:
+        x = input()
+        print(x.upper())
+    except EOFError:
+        break

--- a/python/streaming_stdin.py
+++ b/python/streaming_stdin.py
@@ -1,4 +1,4 @@
-"""Script reads streaming input text and prints capitalized string to stdout"""
+"""Script reads streaming input text and then prints capitalized string to stdout"""
 
 while True:
     try:

--- a/python/test_python.py
+++ b/python/test_python.py
@@ -206,7 +206,7 @@ class TestStreamingStdin:
     """Test that streaming stdin can be read line by line and can write to stdout
     without waiting for all lines to arrive
     Note: this test uses Docker CLI instead of the Python Docker SDK (implemented in the
-    `docker_runner` fixture) since SDK doesn't easily allow for streaming inputs"""
+    `docker_runner` fixture) since SDK doesn't easily allow writing to a container's stdin"""
     def test_stdin(self):
         # Start a subprocess that runs the script and waits for input
         script = subprocess.Popen(

--- a/python/test_python.py
+++ b/python/test_python.py
@@ -206,7 +206,7 @@ class TestStreamingStdin:
     """Test that streaming stdin can be read line by line and can write to stdout
     without waiting for all lines to arrive
     Note: this test uses Docker CLI instead of the Python Docker SDK (implemented in the
-    docker runner fixture) since SDK doen't easily allow for streaming inputs"""
+    `docker_runner` fixture) since SDK doesn't easily allow for streaming inputs"""
     def test_stdin(self):
         # Start a subprocess that runs the script and waits for input
         script = subprocess.Popen(

--- a/python/test_python.py
+++ b/python/test_python.py
@@ -207,18 +207,16 @@ class TestStreamingStdin:
     without waiting for all lines to arrive
     Note: this test uses Docker CLI instead of the Python Docker SDK (implemented in the
     `docker_runner` fixture) since SDK doesn't easily allow writing to a container's stdin"""
-    def test_stdin(self):
-        # Start a subprocess that runs the script and waits for input
+    def test_stdin(self, docker_image):
+        # Subprocess constructor that runs the py script in a docker container and waits for input
         script = subprocess.Popen(
-            ['docker', 'run', '-i', 'python-rosetta', 'python', 'streaming_stdin.py'],
+            ['docker', 'run', '-i', docker_image, 'python', 'streaming_stdin.py'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
+            text=True, # treat standard streams as text, not bytes
+            bufsize=1, # set 1 for line buffering, so buffer is flushed when encountering `\n`
         )
-        # Give input to the script, line by line, and check result
+        # Give input to the script via stdin, one line at a time, and check result
         for i in range(1, 10):
             script.stdin.write(f"line #{i}\n")
-            script.stdin.flush()
             assert script.stdout.readline() == f"LINE #{i}\n"


### PR DESCRIPTION
Test that streaming stdin can be read line by line and can write to stdout without waiting for all lines to arrive
 Note: this test uses Docker CLI instead of the Python Docker SDK (implemented in the `docker_runner` fixture) since SDK doesn't easily allow for streaming inputs"""